### PR TITLE
Fix byte compile error

### DIFF
--- a/discourse-graphs.el
+++ b/discourse-graphs.el
@@ -1469,7 +1469,7 @@ TYPES can be:
                           ((listp types) types)))
          (sql (if type-list
                   (format "SELECT id, type, title FROM nodes WHERE type IN (%s) ORDER BY type, title"
-                          (mapconcat (lambda (t) (format "'%s'" (symbol-name t)))
+                          (mapconcat (lambda (type) (format "'%s'" (symbol-name type)))
                                      type-list ","))
                 "SELECT id, type, title FROM nodes ORDER BY type, title"))
          (rows (sqlite-select (dg--db) sql))


### PR DESCRIPTION
Rename lambda argument name, because using `t` as a lambda parameter causes the byte compile error.

```
discourse-graphs.el:1472:47: Error: Invalid lambda variable t
```

Reference
- https://github.com/emacs-mirror/emacs/blob/emacs-30.2/lisp/emacs-lisp/bytecomp.el#L3011-L3013